### PR TITLE
feat: add dynamic service items to invoice

### DIFF
--- a/app/invoice/ServiceItems.tsx
+++ b/app/invoice/ServiceItems.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import React from "react";
+
+export interface ServiceItem {
+  description: string;
+  quantity: number;
+  unit: string;
+  price: number;
+}
+
+interface Props {
+  items: ServiceItem[];
+  onChange: (items: ServiceItem[]) => void;
+}
+
+export default function ServiceItems({ items, onChange }: Props) {
+  const handleItemChange = (
+    index: number,
+    field: keyof ServiceItem,
+    value: string | number
+  ) => {
+    const updated = items.map((item, i) =>
+      i === index ? { ...item, [field]: value } : item
+    );
+    onChange(updated);
+  };
+
+  const addItem = () => {
+    onChange([
+      ...items,
+      { description: "", quantity: 1, unit: "послуга", price: 0 },
+    ]);
+  };
+
+  const removeItem = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  const total = items.reduce(
+    (sum, item) => sum + item.quantity * item.price,
+    0
+  );
+
+  return (
+    <div className="space-y-4">
+      {items.map((item, index) => (
+        <div key={index} className="border p-4 space-y-2">
+          <label className="block">
+            Опис послуги:
+            <input
+              className="w-full border p-2"
+              value={item.description}
+              onChange={(e) =>
+                handleItemChange(index, "description", e.target.value)
+              }
+              required
+            />
+          </label>
+          <label className="block">
+            Кількість:
+            <input
+              type="number"
+              className="w-full border p-2"
+              value={item.quantity}
+              onChange={(e) =>
+                handleItemChange(index, "quantity", Number(e.target.value))
+              }
+              required
+            />
+          </label>
+          <label className="block">
+            Одиниця виміру:
+            <input
+              className="w-full border p-2"
+              value={item.unit}
+              onChange={(e) => handleItemChange(index, "unit", e.target.value)}
+            />
+          </label>
+          <label className="block">
+            Ціна за одиницю (грн):
+            <input
+              type="number"
+              className="w-full border p-2"
+              value={item.price}
+              onChange={(e) =>
+                handleItemChange(index, "price", Number(e.target.value))
+              }
+              required
+            />
+          </label>
+          <div>Сума: {item.quantity * item.price}</div>
+          {items.length > 1 && (
+            <button
+              type="button"
+              className="px-2 py-1 bg-red-500 text-white rounded"
+              onClick={() => removeItem(index)}
+            >
+              Видалити
+            </button>
+          )}
+        </div>
+      ))}
+      <button
+        type="button"
+        className="px-4 py-2 bg-green-600 text-white rounded"
+        onClick={addItem}
+      >
+        Додати послугу
+      </button>
+      <div className="font-bold">Загальна сума: {total}</div>
+    </div>
+  );
+}
+

--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -20,11 +20,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           <Text>Invoice Number: {data.invoiceNumber}</Text>
           <Text>Date: {data.date}</Text>
           <Text>Client: {data.clientName}</Text>
-          <Text>Service: {data.service}</Text>
-          <Text>
-            Quantity: {data.quantity} {data.unit}
-          </Text>
-          <Text>Price: {data.price}</Text>
+          {data.items?.map((item: any, index: number) => (
+            <Text key={index}>
+              {item.description}: {item.quantity} {item.unit} x {item.price} ={' '}
+              {item.quantity * item.price}
+            </Text>
+          ))}
           <Text>Total: {data.total}</Text>
         </View>
       </Page>


### PR DESCRIPTION
## Summary
- introduce `ServiceItems` component to manage multiple line items with add/remove controls and total calculation
- update invoice form to use dynamic service items and send serialized items with total to backend
- render all line items in generated PDF

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found; dependency installation blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bade661a6883239f6bf715297e1efd