### PR TITLE
Add Ukrainian validators and localized form errors

### DIFF
--- a/lib/validators.ts
+++ b/lib/validators.ts
@@ -1,0 +1,49 @@
+export function isValidIBAN(iban: string): boolean {
+  const normalized = iban.replace(/\s+/g, '').toUpperCase();
+  if (!/^UA\d{27}$/.test(normalized)) return false;
+  const rearranged = normalized.slice(4) + normalized.slice(0, 4);
+  const expanded = rearranged.replace(/[A-Z]/g, (c) => (c.charCodeAt(0) - 55).toString());
+  let remainder = expanded;
+  while (remainder.length > 2) {
+    const block = remainder.slice(0, 9);
+    remainder = (parseInt(block, 10) % 97).toString() + remainder.slice(block.length);
+  }
+  return parseInt(remainder, 10) % 97 === 1;
+}
+
+export function isValidEDRPOU(code: string): boolean {
+  if (!/^\d{8}$/.test(code)) return false;
+  const digits = code.split('').map(Number);
+  const k1 = [1, 2, 3, 4, 5, 6, 7];
+  const k2 = [3, 4, 5, 6, 7, 8, 9];
+  let sum = digits.slice(0, 7).reduce((acc, d, i) => acc + d * k1[i], 0);
+  let control = sum % 11;
+  if (control === 10) {
+    sum = digits.slice(0, 7).reduce((acc, d, i) => acc + d * k2[i], 0);
+    control = sum % 11;
+    if (control === 10) control = 0;
+  }
+  return control === digits[7];
+}
+
+export function isValidIPN(code: string): boolean {
+  if (!/^\d{10}$/.test(code)) return false;
+  const digits = code.split('').map(Number);
+  const weights = [-1, 5, 7, 9, 4, 6, 10, 5, 7];
+  const sum = weights.reduce((acc, w, i) => acc + w * digits[i], 0);
+  const control = (sum % 11) % 10;
+  return control === digits[9];
+}
+
+export function isValidContractNumber(num: string): boolean {
+  return /^\d{1,4}\/\d{2}$/.test(num);
+}
+
+export function formatDateUA(date: string): string {
+  if (!date) return '';
+  const d = new Date(date);
+  const day = String(d.getDate()).padStart(2, '0');
+  const month = String(d.getMonth() + 1).padStart(2, '0');
+  const year = d.getFullYear();
+  return `${day}.${month}.${year}`;
+}

--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -1,5 +1,6 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import { Document, Page, Text, View, StyleSheet, pdf } from '@react-pdf/renderer';
+import { formatDateUA } from '../../lib/validators';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -18,7 +19,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       <Page>
         <View style={styles.section}>
           <Text>Invoice Number: {data.invoiceNumber}</Text>
-          <Text>Date: {data.date}</Text>
+          <Text>Date: {formatDateUA(data.date)}</Text>
           <Text>Client: {data.clientName}</Text>
           <Text>Service: {data.service}</Text>
           <Text>


### PR DESCRIPTION
## Summary
- add validators for IBAN, ЄДРПОУ, ІПН and contract numbers
- validate and show localized messages in invoice form
- format dates to Ukrainian standard in generated PDFs

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bade7f91e08323bf5a435771f5c5ef