### PR TITLE
Add signature and stamp upload with signer transliteration

### DIFF
--- a/app/invoice/ImageUpload.tsx
+++ b/app/invoice/ImageUpload.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+interface ImageUploadProps {
+  label: string;
+  value: string | null;
+  onChange: (value: string | null) => void;
+}
+
+export default function ImageUpload({ label, value, onChange }: ImageUploadProps) {
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) {
+      onChange(null);
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => onChange(reader.result as string);
+    reader.readAsDataURL(file);
+  }
+
+  return (
+    <label className="block">
+      {label}:
+      <input
+        type="file"
+        accept="image/*"
+        className="w-full"
+        onChange={handleFileChange}
+      />
+      {value && (
+        <img
+          src={value}
+          alt={`${label} preview`}
+          className="mt-2 h-24 object-contain border"
+        />
+      )}
+    </label>
+  );
+}

--- a/app/invoice/page.tsx
+++ b/app/invoice/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import ServiceItems, { ServiceItem } from './ServiceItems';
+import ImageUpload from './ImageUpload';
 
 interface FormData {
   invoiceNumber: string;
@@ -13,6 +14,10 @@ interface FormData {
   contact: string;
   email: string;
   items: ServiceItem[];
+  signature: string | null;
+  stamp: string | null;
+  signerName: string;
+  transliterate: boolean;
 }
 
 export default function InvoicePage() {
@@ -28,15 +33,28 @@ export default function InvoicePage() {
     items: [
       { description: '', quantity: 1, unit: 'послуга', price: 0 },
     ],
+    signature: null,
+    stamp: null,
+    signerName: '',
+    transliterate: false,
   });
   const [message, setMessage] = useState('');
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const { name, value, type } = e.target;
+    const { name, value, type, checked } = e.target;
     setData((prev) => ({
       ...prev,
-      [name]: type === 'number' ? Number(value) : value,
+      [name]:
+        type === 'number'
+          ? Number(value)
+          : type === 'checkbox'
+          ? checked
+          : value,
     }));
+  }
+
+  function handleImageChange(name: 'signature' | 'stamp', value: string | null) {
+    setData((prev) => ({ ...prev, [name]: value }));
   }
 
   function handleItemsChange(items: ServiceItem[]) {
@@ -103,6 +121,16 @@ export default function InvoicePage() {
           Email:
           <input type="email" className="w-full border p-2" name="email" value={data.email} onChange={handleChange} />
         </label>
+        <label className="block">
+          ПІБ підписанта:
+          <input className="w-full border p-2" name="signerName" value={data.signerName} onChange={handleChange} />
+        </label>
+        <label className="inline-flex items-center space-x-2">
+          <input type="checkbox" name="transliterate" checked={data.transliterate} onChange={handleChange} />
+          <span>Транслітерувати ПІБ</span>
+        </label>
+        <ImageUpload label="Підпис" value={data.signature} onChange={(v) => handleImageChange('signature', v)} />
+        <ImageUpload label="Печатка" value={data.stamp} onChange={(v) => handleImageChange('stamp', v)} />
         <ServiceItems items={data.items} onChange={handleItemsChange} />
         <button type="submit" className="mt-4 px-4 py-2 bg-blue-600 text-white rounded">Сформувати рахунок</button>
       </form>

--- a/pages/api/generate.ts
+++ b/pages/api/generate.ts
@@ -1,5 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { Document, Page, Text, View, StyleSheet, pdf } from '@react-pdf/renderer';
+import { Document, Page, Text, View, StyleSheet, pdf, Image } from '@react-pdf/renderer';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'POST') {
@@ -8,6 +8,27 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const data = req.body;
+
+  const ukToLatin: Record<string, string> = {
+    А: 'A', а: 'a', Б: 'B', б: 'b', В: 'V', в: 'v', Г: 'H', г: 'h', Ґ: 'G', ґ: 'g',
+    Д: 'D', д: 'd', Е: 'E', е: 'e', Є: 'Ye', є: 'ie', Ж: 'Zh', ж: 'zh', З: 'Z', з: 'z',
+    И: 'Y', и: 'y', І: 'I', і: 'i', Ї: 'Yi', ї: 'i', Й: 'Y', й: 'i', К: 'K', к: 'k',
+    Л: 'L', л: 'l', М: 'M', м: 'm', Н: 'N', н: 'n', О: 'O', о: 'o', П: 'P', п: 'p',
+    Р: 'R', р: 'r', С: 'S', с: 's', Т: 'T', т: 't', У: 'U', у: 'u', Ф: 'F', ф: 'f',
+    Х: 'Kh', х: 'kh', Ц: 'Ts', ц: 'ts', Ч: 'Ch', ч: 'ch', Ш: 'Sh', ш: 'sh',
+    Щ: 'Shch', щ: 'shch', Ю: 'Yu', ю: 'iu', Я: 'Ya', я: 'ia', Ь: '', ь: '', "'": ''
+  };
+
+  function transliterate(text: string) {
+    return text
+      .split('')
+      .map((ch) => (ukToLatin as any)[ch] ?? ch)
+      .join('');
+  }
+
+  const signerName = data.transliterate
+    ? transliterate(data.signerName || '')
+    : data.signerName;
 
   const styles = StyleSheet.create({
     section: { margin: 10, padding: 10, fontSize: 12 },
@@ -27,6 +48,25 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
             </Text>
           ))}
           <Text>Total: {data.total}</Text>
+          {(data.signature || data.stamp) && (
+            <View
+              style={{ marginTop: 20, flexDirection: 'row', alignItems: 'center' }}
+            >
+              {data.signature && (
+                <Image
+                  src={data.signature}
+                  style={{ width: 100, height: 50, objectFit: 'contain', marginRight: 20 }}
+                />
+              )}
+              {data.stamp && (
+                <Image
+                  src={data.stamp}
+                  style={{ width: 100, height: 100, objectFit: 'contain' }}
+                />
+              )}
+            </View>
+          )}
+          {signerName && <Text style={{ marginTop: 10 }}>Signer: {signerName}</Text>}
         </View>
       </Page>
     </Document>


### PR DESCRIPTION
## Summary
- add reusable image upload component for signature/stamp previews
- extend invoice form to upload signature/stamp images and optionally transliterate signer name
- embed uploaded images and transliterated signer into generated PDF

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*
- `npx eslint .` *(fails: ESLint couldn't find the config "next/typescript" to extend from)*
- `npm run build` *(fails: Configuring Next.js via 'next.config.ts' is not supported)*

------
https://chatgpt.com/codex/tasks/task_e_68badfd1d13c8323af5463a2419397b8