### PR TITLE
feat: persist form data locally

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
 </head>
 <body>
   <h1>Форма для створення рахунку</h1>
+  <p id="consent-notice">Введені дані зберігаються локально у вашому браузері для автозаповнення та не передаються третім сторонам.</p>
   <form id="invoice-form">
     <label>Номер рахунку: <input type="text" name="invoiceNumber" required /></label>
     <label>Дата: <input type="date" name="date" required /></label>
@@ -28,12 +29,43 @@
     <label>Сума (грн): <input type="number" name="total" required /></label>
 
     <button type="submit">Сформувати рахунок</button>
+    <button type="button" id="clear-data">Очистити дані</button>
   </form>
 
   <div id="result" style="margin-top:2rem;"></div>
 
   <script>
     const form = document.getElementById('invoice-form');
+    const storageKey = 'invoiceFormData';
+
+    function saveData() {
+      const data = Object.fromEntries(new FormData(form).entries());
+      localStorage.setItem(storageKey, JSON.stringify(data));
+    }
+
+    function loadData() {
+      const saved = localStorage.getItem(storageKey);
+      if (saved) {
+        const data = JSON.parse(saved);
+        for (const [key, value] of Object.entries(data)) {
+          if (form.elements[key]) {
+            form.elements[key].value = value;
+          }
+        }
+      }
+    }
+
+    function clearData() {
+      localStorage.removeItem(storageKey);
+      form.reset();
+      document.getElementById('result').textContent = '';
+    }
+
+    form.addEventListener('input', saveData);
+    document.getElementById('clear-data').addEventListener('click', clearData);
+
+    loadData();
+
     form.addEventListener('submit', async (e) => {
       e.preventDefault();
 


### PR DESCRIPTION
## Summary
- persist form inputs in localStorage and restore on load
- show consent notice about local processing and offer clear button
- allow users to clear saved form data with one click

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bad8010b688323b9ca7785ee713ee7